### PR TITLE
fix Trying to get property 'attributes' of non-object, fix #26

### DIFF
--- a/Security/SpidAuthenticator.php
+++ b/Security/SpidAuthenticator.php
@@ -52,7 +52,7 @@ class SpidAuthenticator extends AbstractGuardAuthenticator
      */
     public function getUser($credentials, UserProviderInterface $userProvider): UserInterface
     {
-        return $userProvider->loadUserByUsername($credentials->attributes['fiscalNumber']);
+        return $userProvider->loadUserByUsername($credentials["attributes"]['fiscalNumber']);
     }
 
     /**


### PR DESCRIPTION
Da:

    public function getUser($credentials, UserProviderInterface $userProvider): UserInterface
    {
        return $userProvider->loadUserByUsername($credentials->attributes['fiscalNumber']);
    }

a:

    public function getUser($credentials, UserProviderInterface $userProvider): UserInterface
    {
        return $userProvider->loadUserByUsername($credentials["attributes"]['fiscalNumber']);
    }

