### PR TITLE
Compatibilita Symfony 4

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,8 +13,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('spid');
+        $treeBuilder = new TreeBuilder('spid');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode->children()
             ->scalarNode('sp_entityid')->isRequired()->cannotBeEmpty()->defaultValue('%spid_symfony.sp_entityid%')->end()


### PR DESCRIPTION
Esistono delle funzioni deprecate in Symfony 4 che restituiscono dei warning.
In questa modifica ho modificato l'istanza del TreeBuilder, utilizzando il costruttore anzichè il metodo root()